### PR TITLE
Remove useBuiltIns option from babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,10 +1,12 @@
 {
   "presets": [
-    
-    ["@babel/preset-env", {
-      "shippedProposals": true, "useBuiltIns": "usage"
-      }],
-      "@babel/preset-react",
-      "@babel/preset-flow"
+    [
+      "@babel/preset-env",
+      {
+        "shippedProposals": true
+      }
+    ],
+    "@babel/preset-react",
+    "@babel/preset-flow"
   ]
 }


### PR DESCRIPTION
While useBuiltIns is set to "usage", any project that isn't using the same version of corejs will break due to changes in paths and file names.

These polyfills will be included in the end users final build if needed and shouldn't be included in this package imo.

```
require("core-js/modules/es6.array.filter");

require("core-js/modules/es6.object.define-property");

require("core-js/modules/es6.string.iterator");

require("core-js/modules/es6.array.from");

require("core-js/modules/es6.regexp.to-string");

require("core-js/modules/es6.date.to-string");

require("core-js/modules/es7.symbol.async-iterator");

require("core-js/modules/es6.symbol");

require("core-js/modules/es6.array.is-array");

require("core-js/modules/es6.array.sort");

require("core-js/modules/web.dom.iterable");

require("core-js/modules/es6.array.iterator");

require("core-js/modules/es6.object.to-string");

require("core-js/modules/es6.object.keys");

require("core-js/modules/es6.regexp.replace");

require("core-js/modules/es6.array.map");

require("core-js/modules/es6.array.reduce");

require("core-js/modules/es6.array.for-each");

require("core-js/modules/es6.function.name");
```