### PR TITLE
Fix select knob. Hide empty option if required.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,14 +42,17 @@ typeKnobsMap.forEach(({ name, knob, args = [] }, weight) => addKnobResolver({
 }))
 
 const optionsReducer = (res, value) => ({ ...res, [value]: value })
-const withDefaultOption = (options) => ({ '': '--', ...options })
-const createSelect = (propName, elements, defaultProps) => {
+const withDefaultOption = (options) => ({ ' ': null, ...options })
+const createSelect = (propName, elements, defaultProps, isRequired) => {
   try {
     const options = elements
     // Cleanup string quotes, if any.
       .map(value => value.value.replace(/^['"](.*)['"]$/, '$1'))
       .reduce(optionsReducer, {})
-    return select(propName, withDefaultOption(options), defaultProps[propName])
+
+      const defaultValue = defaultProps[propName]
+
+    return select(propName, isRequired || defaultValue ? options : withDefaultOption(options), defaultValue)
   }
   catch (e) { }
 }
@@ -59,11 +62,11 @@ addKnobResolver({
   name: 'PropTypes.oneOf',
   resolver: (propName, propType, value, propTypes, defaultProps) => {
     if (propType.type.name === 'enum' && propType.type.value.length) {
-      return createSelect(propName, propType.type.value, defaultProps)
+      return createSelect(propName, propType.type.value, defaultProps, propType.required)
     }
     // for flow support
     if (propType.type.name === 'union' && propType.type.elements) {
-      return createSelect(propName, propType.type.elements, defaultProps)
+      return createSelect(propName, propType.type.elements, defaultProps, propType.required)
     }
   }
 })


### PR DESCRIPTION
Similar to https://github.com/storybookjs/addon-smart-knobs/pull/60

Difference is in covering flow definitions. _propType.required_ is always **false** for flow.