### PR TITLE
chore(docs): Add CSF examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,53 @@ This Storybook plugin uses `@storybook/addon-knobs` but creates the knobs automa
 ## Installation:
 
 ```
-npm i storybook-addon-smart-knobs --save-dev
+npm i @storybook/addon-knobs storybook-addon-smart-knobs --save-dev
 ```
 
 ## Usage:
+
+### Component Story Format (CSF)
+
+```js
+import React from 'react'
+import PropTypes from 'prop-types'
+import { storiesOf } from '@storybook/react'
+import { withKnobs } from '@storybook/addon-knobs'
+import { withSmartKnobs } from 'storybook-addon-smart-knobs'
+
+const Button = ({ children, onClick }) => (
+  <button onClick={ onClick }>{ children }</button>
+)
+
+Button.propTypes = {
+  children: PropTypes.node,
+  onClick: PropTypes.func
+}
+
+export default {
+  title: 'Button',
+  component: Button,
+  decorators: [[withKnobs, withSmartKnobs(options)]]
+};
+
+export const simple = () => <Button>Smart knobed button</Button>)
+```
+
+To apply the smart knobs to a specific story:
+
+```js
+export default {
+  title: 'Button',
+  component: Button,
+};
+
+export const simple = () => <Button>Smart knobed button</Button>)
+simple.story = {
+  decorators: [[withKnobs, withSmartKnobs(options)]]
+}
+```
+
+### `storiesOf` API
 
 ```js
 import React from 'react'
@@ -30,7 +73,15 @@ storiesOf('Button')
   .addDecorator(withSmartKnobs(options))
   .addDecorator(withKnobs)
   .add('simple', () => <Button>Smart knobed button</Button>)
+```
 
+To apply the smart knobs to a specific story:
+
+```js
+storiesOf('Button')
+  .add('simple', () => <Button>Smart knobed button</Button>, {
+    decorators: [[withKnobs, withSmartKnobs(options)]]
+  })
 ```
 
 ## Options
@@ -41,7 +92,7 @@ storiesOf('Button')
 
   Will not automatically create knobs for props whose name is in this array. Example:
   ```js
-    .withSmartKnobs({ ignoreProps: ['numberProp'] })
+    .addDecorator(withSmartKnobs({ ignoreProps: ['numberProp'] }))
     .add('example', () => <div numberProp={date('date', date)} />) 
   ```
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,24 @@
 # Smart knobs addon for Storybook
 
-This Storybook plugin uses `@storybook/addon-knobs` but creates the knobs automatically based on PropTypes, Flow and Typescript.
+This Storybook plugin uses [`@storybook/addon-knobs`](https://github.com/storybookjs/storybook/tree/next/addons/knobs) but creates the knobs automatically based on PropTypes, Flow and Typescript.
 
 ## Installation:
 
-```
+Via npm:
+
+```sh
 npm i @storybook/addon-knobs storybook-addon-smart-knobs --save-dev
 ```
 
+or with Yarn:
+
+```sh
+yarn add @storybook/addon-knobs storybook-addon-smart-knobs --dev
+```
+
 ## Usage:
+
+Follow the `@storybook/addon-knobs` [Getting started steps](https://github.com/storybookjs/storybook/tree/master/addons/knobs), and then:
 
 ### Component Story Format (CSF)
 
@@ -31,7 +41,7 @@ Button.propTypes = {
 export default {
   title: 'Button',
   component: Button,
-  decorators: [[withKnobs, withSmartKnobs(options)]]
+  decorators: [withKnobs, withSmartKnobs(options)]
 };
 
 export const simple = () => <Button>Smart knobed button</Button>)


### PR DESCRIPTION
## Problem

I had two problems:

1. I was unsure if I had to install [`@storybook/addon-knobs`](https://github.com/storybookjs/storybook/tree/master/addons/knobs) with `storybook-addon-smart-knobs`
1. The examples were not in [Component Story Format](https://storybook.js.org/docs/formats/component-story-format/) so I wasn't sure what the equivalent CSF code looked like. Once I did, I was also unsure what order the decorators should go in.

## Solution

I updated the installation instructions to include `@storybook/addon-knobs` for extra clarity.

The main part was adding examples for CSF. I have some set of stories that display the component multiple times in a story, so including the decorator globally messed up those stories because it was passing the same parameters into all of the components. So I added an example of adding the decorator at the story level.

## Notes

I also added a fix for what I believe was a bug in the `ignoreProps` options example.