### PR TITLE
Respect falsy default props (fixes #73)

### DIFF
--- a/example/stories/SmartKnobedComponentWithDefaultProps.js
+++ b/example/stories/SmartKnobedComponentWithDefaultProps.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { PropTable } from './PropTable'
+
+const SmartKnobedComponentWithDefaultProps = props => <PropTable { ...props } docgenInfo={ SmartKnobedComponentWithDefaultProps.__docgenInfo } />
+
+SmartKnobedComponentWithDefaultProps.propTypes = {
+  bool: PropTypes.bool,
+  number: PropTypes.number,
+  string: PropTypes.string,
+  func: PropTypes.func,
+  oneOf: PropTypes.oneOf(['one', 'two', 'three']),
+  object: PropTypes.object,
+  element: PropTypes.element,
+  node: PropTypes.node,
+}
+
+SmartKnobedComponentWithDefaultProps.defaultProps = {
+  bool: false,
+  number: 0,
+  string: '',
+  func: null,
+  oneOf: 'one',
+  object: {},
+  element: null,
+  node: '',
+}
+
+export default SmartKnobedComponentWithDefaultProps

--- a/example/stories/index.js
+++ b/example/stories/index.js
@@ -6,6 +6,7 @@ import { withInfo } from '@storybook/addon-info'
 
 import SmartKnobedComponent from './SmartKnobedComponent'
 import SmartKnobedComponentMissingProps from './SmartKnobedComponentMissingProps'
+import SmartKnobedComponentWithDefaultProps from './SmartKnobedComponentWithDefaultProps'
 import SmartKnobedComponentWithFlow from './SmartKnobedComponentWithFlow'
 import { SmartKnobedComponentWithTypescript } from './SmartKnobedComponentWithTypescript'
 
@@ -29,6 +30,13 @@ storiesOf('withInfo', module)
   .addDecorator(withKnobs)
   .addDecorator(withInfo)
   .add('proptypes', () => <SmartKnobedComponent />)
+
+storiesOf('Default props', module)
+  .addDecorator(withSmartKnobs())
+  .addDecorator(withKnobs)
+  .add('example', () => (
+    <SmartKnobedComponentWithDefaultProps />
+  ))
 
 storiesOf('Missing props', module)
   .addDecorator(withSmartKnobs())

--- a/src/index.js
+++ b/src/index.js
@@ -135,6 +135,20 @@ export const withSmartKnobs = (opts = {}) => (story, context) => {
   return cloneElement(component, newProps)
 }
 
+const getDefaultValue = (defaultProp, propType) => {
+  // If the defaultProp is not undefined, return it. This avoids relying on the
+  // truthiness of the value, which doesn't work for falsy values.
+  if (typeof defaultProp !== 'undefined') {
+    return defaultProp
+  }
+
+  if (propType.defaultValue) {
+    return cleanupValue(propType.defaultValue.value)
+  }
+
+  return undefined
+}
+
 const resolvePropValues = (propTypes, defaultProps) => {
   const propNames = Object.keys(propTypes)
   const resolvers = Object.keys(knobResolvers)
@@ -145,7 +159,7 @@ const resolvePropValues = (propTypes, defaultProps) => {
     .map(propName => resolvers.reduce(
       (value, resolver) => {
         const propType = propTypes[propName] || {}
-        const defaultValue = defaultProps[propName] || (propType.defaultValue && cleanupValue(propType.defaultValue.value || '')) || undefined
+        const defaultValue = getDefaultValue(defaultProps[propName], propType)
 
         return value !== undefined ? value
           : resolver(propName, propType, defaultValue)


### PR DESCRIPTION
Falsy default props are coerced to strings:

`false` becomes `"false"`
`0` becomes `"0"`
`null` becomes `"null"`

I've added `SmartKnobedComponentWithDefaultProps.js` to help illustrate this. Without this fix, falsy values are coerced to strings:

![Screen Shot 2020-02-13 at 9 26 37 PM](https://user-images.githubusercontent.com/739304/74497235-16603780-4eab-11ea-9c79-050ee2aa9a61.png)

The associated knobs get string values, which generates `propType` warnings and subverts the actual default value. It makes boolean knobs _completely_ unusable since both.the unchecked and checked value are effectively true. (Note in the screenshot that the checkbox is checked even though we've provided `false`.)

With this fix, we receive the expected types and values:

![Screen Shot 2020-02-13 at 9 25 11 PM](https://user-images.githubusercontent.com/739304/74497243-1eb87280-4eab-11ea-85fe-edee0f2f624e.png)
