### PR TITLE
Groups of knobs to organize multiple components on the same page

### DIFF
--- a/example/stories/index.js
+++ b/example/stories/index.js
@@ -49,3 +49,13 @@ storiesOf('Ignore Props', module)
   .addDecorator(withSmartKnobs({ ignoreProps: ['number'] }))
   .addDecorator(withKnobs)
   .add('proptypes', () => <SmartKnobedComponent number={ date('date', new Date()) } />)
+
+storiesOf('Multiple components', module)
+  .addDecorator(withSmartKnobs())
+  .addDecorator(withKnobs)
+  .add('example', () => (
+    <>
+      <SmartKnobedComponent />
+      <SmartKnobedComponent />
+    </>
+  ))


### PR DESCRIPTION
If the same component is several times in the same story, groups are automatically generated based on the children's index in order to put them in tabs and prevent conflicts between props.

Also, it fix the documentation page issue in storybook/addon-knobs.

Maybe it would be possible to customize these names to make groups more verbose.

Fix. https://github.com/storybookjs/addon-smart-knobs/issues/71