### PR TITLE
feature: Github Action for CI and Deploy to GH Pages on push to master

### DIFF
--- a/.github/workflows/ci_and_deploy.yaml
+++ b/.github/workflows/ci_and_deploy.yaml
@@ -1,0 +1,31 @@
+name: CI and Deploy to GH-Pages
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - run: npm run build-storybook
+    - name: Deploy to GitHub Pages
+      uses: Cecilapp/GitHub-Pages-deploy@master
+      env:
+        EMAIL: ${{ secrets.email }}
+        GH_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+        BUILD_DIR: storybook-static

--- a/.github/workflows/ci_and_deploy.yaml
+++ b/.github/workflows/ci_and_deploy.yaml
@@ -3,8 +3,6 @@ name: CI and Deploy to GH-Pages
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 jobs:
   build:


### PR DESCRIPTION
Adds a Github Action which builds, and deploys to github pages.
to support this, you'll have to add two secrets to the project:

1. secrets.email with your email address
1. secrets.ACCESS_TOKEN with a github personal access token with only public_repo scope

Results in a github pages static site of the storybook. See https://barakplasma.github.io/addon-smart-knobs/ as an example. However, if merged to master, then the URL will be https://storybookjs.github.io/addon-smart-knobs/ instead.

replaces #57 